### PR TITLE
Upgrade `thiserror` and `nonempty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["http"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1"
+thiserror = "2"
 nonempty = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["http"]
 
 [dependencies]
 thiserror = "2"
-nonempty = "0.7"
+nonempty = "0.11"


### PR DESCRIPTION
Could a new release be made to crates.io after merging this?